### PR TITLE
Refactor get entry info

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import setuptools
+
 setuptools.setup(
     name="swcregistrypython",
     version="1.0",
@@ -18,4 +19,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4'
     ],
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"]
 )

--- a/tests/test_get_entry_info.py
+++ b/tests/test_get_entry_info.py
@@ -1,40 +1,42 @@
 import unittest
 import json
+import os
 
 from unittest.mock import MagicMock
-from get_entry_info import SWC
+from swcregistrypython import SWC
+from swcregistrypython.get_entry_info import SWCRegistry
 
 
 class TestMethods(unittest.TestCase):
     def setUp(self):
-        with open('swc-definition.json') as f:
+        with open(os.path.dirname(__file__) + '/../swcregistrypython/swc-definition.json') as f:
             self.object = json.load(f)
         self.swc = SWC('SWC-100')
-     
+        SWCRegistry()._load_from_file()
+
     def test_get_title(self):
-        self.swc.content = MagicMock(return_value=self.object['SWC-100']['content'])
         self.assertEqual(self.swc.title, self.object['SWC-100']['content']['Title'])
 
     def test_get_relationships(self):
-        self.swc.content = MagicMock(return_value=self.object['SWC-100']['content'])
         self.assertEqual(self.swc.relationships, self.object['SWC-100']['content']['Relationships'])
 
     def test_get_description(self):
-        self.swc.content = MagicMock(return_value=self.object['SWC-100']['content'])
         self.assertEqual(self.swc.description, self.object['SWC-100']['content']['Description'])
     
     def test_get_remediation(self):
-        self.swc.content = MagicMock(return_value=self.object['SWC-100']['content'])
         self.assertEqual(self.swc.remediation, self.object['SWC-100']['content']['Remediation'])
 
     def test_get_last_version(self):
-        self.object['SWC-100']['content']['Title'] = "Test"
-        with open('swc-definition.json', 'w') as f:
-            json.dump(self.object, f)
-        self.assertEqual(self.swc.title, "Test")
-        
-        self.swc.get_last_version
-        self.assertNotEqual(self.swc.title, "Test")
+        # Act
+        after_content = SWCRegistry().content
+        after_content['SWC-100']['content']['Title'] = "Brick"
+        SWCRegistry._get_latest_version = MagicMock(return_value=after_content)
+
+        SWCRegistry().update()
+
+        # Assert
+        new_title = self.swc.title
+        self.assertEqual(new_title, "Brick")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hey guys, I had some time to kill so I added some things I would like to have included
Summary:
- Move loading logic to separate singleton class
- Don't write on an update
  - I removed this because otherwise you are writing to a directory used for installed packages (right?), I don't think thats always allowed
- Refactor the functions of SWC, making some private and some not properties

- Move test outside of packaged directory

- Create setup.py test command
`python setup.py test` runs the test suite (maybe useful for ci)

Edit:
fixes #3 