### PR TITLE
Specify encoding for open file

### DIFF
--- a/swc_registry/get_entry_info.py
+++ b/swc_registry/get_entry_info.py
@@ -40,7 +40,7 @@ class SWCRegistry(object, metaclass=Singleton):
         path_file_content = os.path.join(
             os.path.dirname(__file__), "swc-definition.json"
         )
-        with open(path_file_content, "r") as f:
+        with open(path_file_content, "r", encoding="utf-8") as f:
             self._content = json.load(f)
 
     def update(self):

--- a/tests/test_get_entry_info.py
+++ b/tests/test_get_entry_info.py
@@ -10,7 +10,7 @@ from swc_registry.get_entry_info import SWCRegistry
 class TestMethods(unittest.TestCase):
     def setUp(self):
         with open(
-            os.path.dirname(__file__) + "/../swc_registry/swc-definition.json"
+            os.path.dirname(__file__) + "/../swc_registry/swc-definition.json", encoding="utf-8"
         ) as f:
             self.object = json.load(f)
         self.swc = SWC("SWC-100")


### PR DESCRIPTION
E       UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in
position 2534: illegal multibyte sequence

When opening a file, a decode error occurred. So I specified the
encoding type as utf8 in the open function. :)